### PR TITLE
중복된 구 장소정보 활성화

### DIFF
--- a/src/main/java/com/travelock/server/client/PlaceSummaryClient.java
+++ b/src/main/java/com/travelock/server/client/PlaceSummaryClient.java
@@ -8,6 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -15,9 +18,20 @@ public class PlaceSummaryClient {
 
     private final WebClient webClient = WebClient.builder().build();
 
-    public PlaceSummaryResponseDTO fetchCitySummary(String cityName) {
-        String wikipediaApiUrl = "https://ko.wikipedia.org/api/rest_v1/page/summary/" + cityName;
-        log.info("PlaceSummaryClient::fetchCitySummary START - cityName: {}", cityName);
+    // 중복된 도시 이름 목록 (Set을 사용하여 중복 확인)
+    private final Set<String> duplicatedCityNames = new HashSet<>(Set.of("중구", "서구", "동구", "남구", "북구"));
+
+    public PlaceSummaryResponseDTO fetchCitySummary(String stateName, String cityName) {
+        // 중복된 도시 이름인지 확인하고, 중복된 경우 stateName과 결합
+        String searchKeyword;
+        if (duplicatedCityNames.contains(cityName)) {
+            searchKeyword = cityName + "_(" + stateName + ")";
+        } else {
+            searchKeyword = cityName;
+        }
+
+        String wikipediaApiUrl = "https://ko.wikipedia.org/api/rest_v1/page/summary/" + searchKeyword;
+        log.info("PlaceSummaryClient::fetchCitySummary START - searchKeyword: {}", searchKeyword);
 
         // Wikipedia API 호출
         String jsonString = webClient.get()

--- a/src/main/java/com/travelock/server/controller/PlaceSummaryController.java
+++ b/src/main/java/com/travelock/server/controller/PlaceSummaryController.java
@@ -23,8 +23,9 @@ public class PlaceSummaryController {
 
     @Operation(summary = "도시 요약 정보 조회",
             tags = {"Place Summary API"},
-            description = "지정된 도시 이름으로 위키피디아에서 도시 요약 정보를 가져옵니다.",
+            description = "지정된 시/도 이름과 도시 이름으로 위키피디아에서 도시 요약 정보를 가져옵니다.",
             parameters = {
+                    @Parameter(name = "stateName", description = "조회할 시/도 이름", required = true, in = ParameterIn.QUERY),
                     @Parameter(name = "cityName", description = "조회할 도시 이름", required = true, in = ParameterIn.QUERY),
             },
             responses = {
@@ -32,9 +33,9 @@ public class PlaceSummaryController {
                     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json")),
                     @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json")),
             })
-    @GetMapping("/info")
-    public ResponseEntity<PlaceSummaryResponseDTO> getCitySummary(@RequestParam String cityName) {
-        PlaceSummaryResponseDTO citySummary = placeSummaryService.getCitySummary(cityName);
+    @GetMapping("/info/t1")
+    public ResponseEntity<PlaceSummaryResponseDTO> getCitySummary(@RequestParam String stateName, @RequestParam String cityName) {
+        PlaceSummaryResponseDTO citySummary = placeSummaryService.getCitySummary(stateName, cityName);
         return ResponseEntity.ok(citySummary);
     }
 }

--- a/src/main/java/com/travelock/server/controller/SmallBlockController.java
+++ b/src/main/java/com/travelock/server/controller/SmallBlockController.java
@@ -50,27 +50,6 @@ public class SmallBlockController {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-//
-//    @Operation(summary = "추천 스몰블록 조회",
-//            tags = {"스몰블록 API - V1"},
-//            description = "referenceCount가 높은 순으로 스몰블록을 조회.",
-//            parameters = {
-//                    @Parameter(name = "limit", description = "조회할 개수", required = true, in = ParameterIn.QUERY)
-//            },
-//            responses = {
-//                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json")),
-//                    @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(mediaType = "application/json"))
-//            })
-//    @GetMapping("/popular")
-//    public ResponseEntity<List<SmallBlockResponseDTO>> getPopularSmallBlocks(@RequestParam int limit) {
-//        try {
-//            List<SmallBlockResponseDTO> popularSmallBlocks = smallBlockService.getPopularSmallBlocks(limit);
-//            return ResponseEntity.ok(popularSmallBlocks);
-//        } catch (Exception e) {
-//            log.error("Error fetching popular SmallBlocks", e);
-//            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-//        }
-//    }
 
     @Operation(summary = "시군구별 추천 스몰블록 조회",
             tags = {"스몰블록 API - V1"},

--- a/src/main/java/com/travelock/server/service/PlaceSummaryService.java
+++ b/src/main/java/com/travelock/server/service/PlaceSummaryService.java
@@ -11,8 +11,7 @@ public class PlaceSummaryService {
 
     private final PlaceSummaryClient placeSummaryClient;
 
-    public PlaceSummaryResponseDTO getCitySummary(String cityName) {
-        return placeSummaryClient.fetchCitySummary(cityName);
+    public PlaceSummaryResponseDTO getCitySummary(String stateName, String cityName) {
+        return placeSummaryClient.fetchCitySummary(stateName, cityName);
     }
-    
 }


### PR DESCRIPTION
HashSet 사용하여 중복 구별 로직 추가 
만약 전국에 동일한 구가 존재하는 경우, 위키피디아 API 형식에 맞게 '중구_(서울특별시)' 로 변환 후 검색 
유일한 시/군/구라면 그대로 '포항시' 로만 검색. 